### PR TITLE
Fix payment gateway count error debugged

### DIFF
--- a/tickera.php
+++ b/tickera.php
@@ -867,18 +867,9 @@ if ( !class_exists( 'TC' ) ) {
 		}
 
 		function active_payment_gateways() {
-            global $tc, $tc_gateway_active_plugins, $tc_gateway_plugins;
-
-            /**
-             * Check if array first, then count, because 
-             * $tc_gateway_active_plugins can return as not array
-             */
-            if(is_array($tc_gateway_active_plugins)) {
-                return count($tc_gateway_active_plugins);
-            } else {
-                return 0;
-            }
-        }
+			global $tc, $tc_gateway_active_plugins, $tc_gateway_plugins;
+			return count( $tc_gateway_active_plugins );
+		}
 
 		function tc_checkout_payment_form( $content, $cart ) {
 			global $tc, $tc_gateway_active_plugins, $tc_gateway_plugins;

--- a/tickera.php
+++ b/tickera.php
@@ -867,9 +867,18 @@ if ( !class_exists( 'TC' ) ) {
 		}
 
 		function active_payment_gateways() {
-			global $tc, $tc_gateway_active_plugins, $tc_gateway_plugins;
-			return count( $tc_gateway_active_plugins );
-		}
+            global $tc, $tc_gateway_active_plugins, $tc_gateway_plugins;
+
+            /**
+             * Check if array first, then count, because 
+             * $tc_gateway_active_plugins can return as not array
+             */
+            if(is_array($tc_gateway_active_plugins)) {
+                return count($tc_gateway_active_plugins);
+            } else {
+                return 0;
+            }
+        }
 
 		function tc_checkout_payment_form( $content, $cart ) {
 			global $tc, $tc_gateway_active_plugins, $tc_gateway_plugins;


### PR DESCRIPTION
If $tc_gateway_active_plugins is not an array, user receives a PHP Countable error. This code checks for array first, then counts or returns zero. Received error after copying Wordpress install from one server to another, and trying to load new or pre-existing Tickera plugin.

Error:
`Warning: count(): Parameter must be an array or an object that implements Countable`